### PR TITLE
enable Maven 4 build

### DIFF
--- a/.github/workflows/maven-verify.yml
+++ b/.github/workflows/maven-verify.yml
@@ -25,3 +25,5 @@ jobs:
   build:
     name: Verify
     uses: apache/maven-gh-actions-shared/.github/workflows/maven-verify.yml@v4
+    with:
+      maven4-enabled: true

--- a/src/it/reactor/sub/pom.xml
+++ b/src/it/reactor/sub/pom.xml
@@ -23,14 +23,12 @@ under the License.
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.apache.maven.its.ejb</groupId>
-    <artifactId>maven-ejb-it-setup</artifactId>
+    <groupId>org.apache.maven.its.ejb.reactor</groupId>
+    <artifactId>aggregator</artifactId>
     <version>1.0</version>
   </parent> 
 
-  <groupId>org.apache.maven.its.ejb.reactor</groupId>
   <artifactId>sub</artifactId>
-  <version>1.0</version>
   <packaging>ejb</packaging>
 
   <name>Maven Integration Test</name> 


### PR DESCRIPTION
failing IT with Maven 4.0.0-rc-5 (regression from 4.0.0-rc-4):
```
[INFO] -------------------------------------------------
[INFO] Build Summary:
[INFO]   Passed: 8, Failed: 1, Errors: 0, Skipped: 0
[INFO] -------------------------------------------------
[ERROR] The following builds failed:
[ERROR] *  reactor/pom.xml
[INFO] -------------------------------------------------
```

because
```
[ERROR] Some problems were encountered while processing the POMs
[ERROR] The build could not read 1 project -> [Help 1]
org.apache.maven.project.ProjectBuildingException: Some problems were encountered while processing the POMs
    at org.apache.maven.project.DefaultProjectBuilder$BuildSession.build(DefaultProjectBuilder.java:511)
    at org.apache.maven.project.DefaultProjectBuilder.build(DefaultProjectBuilder.java:194)
    at org.apache.maven.project.collector.DefaultProjectsSelector.selectProjects(DefaultProjectsSelector.java:61)
    at org.apache.maven.project.collector.RequestPomCollectionStrategy.collectProjects(RequestPomCollectionStrategy.java:49)
    at org.apache.maven.graph.DefaultGraphBuilder.getProjectsForMavenReactor(DefaultGraphBuilder.java:367)
    at org.apache.maven.graph.DefaultGraphBuilder.build(DefaultGraphBuilder.java:100)
    at org.apache.maven.DefaultMaven.buildGraph(DefaultMaven.java:643)
    at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:250)
    at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:225)
    at org.apache.maven.DefaultMaven.execute(DefaultMaven.java:149)
    at org.apache.maven.cling.invoker.mvn.MavenInvoker.doExecute(MavenInvoker.java:452)
    at org.apache.maven.cling.invoker.mvn.MavenInvoker.execute(MavenInvoker.java:97)
    at org.apache.maven.cling.invoker.mvn.MavenInvoker.execute(MavenInvoker.java:81)
    at org.apache.maven.cling.invoker.LookupInvoker.doInvoke(LookupInvoker.java:165)
    at org.apache.maven.cling.invoker.LookupInvoker.invoke(LookupInvoker.java:134)
    at org.apache.maven.cling.ClingSupport.run(ClingSupport.java:76)
    at org.apache.maven.cling.MavenCling.main(MavenCling.java:51)
    at jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
    at java.lang.reflect.Method.invoke(Method.java:565)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced(Launcher.java:255)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launch(Launcher.java:201)
    at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode(Launcher.java:361)
    at org.codehaus.plexus.classworlds.launcher.Launcher.main(Launcher.java:314)
[ERROR]   
[ERROR]   The project org.apache.maven.its.ejb.reactor:aggregator:1.0 (/home/herve/dev/maven/sources/plugins/packaging/maven-ejb-plugin/target/it/reactor/pom.xml) has 2 errors
[ERROR]     The parents form a cycle: org.apache.maven.its.ejb:maven-ejb-it-setup:1.0 -> /home/herve/dev/maven/sources/plugins/packaging/maven-ejb-plugin/target/it/reactor/pom.xml -> org.apache.maven.its.ejb:maven-ejb-it-setup:1.0
[ERROR]     The parents form a cycle: org.apache.maven.its.ejb:maven-ejb-it-setup:1.0 -> /home/herve/dev/maven/sources/plugins/packaging/maven-ejb-plugin/target/it/reactor/pom.xml -> org.apache.maven.its.ejb:maven-ejb-it-setup:1.0
```