### PR TITLE
Bump org.eclipse.sisu:org.eclipse.sisu.plexus and org.eclipse.sisu.inject to 1.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -128,8 +128,14 @@ under the License.
     </dependency>
     <dependency>
       <groupId>org.eclipse.sisu</groupId>
+      <artifactId>org.eclipse.sisu.inject</artifactId>
+      <version>1.1.0</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.sisu</groupId>
       <artifactId>org.eclipse.sisu.plexus</artifactId>
-      <version>1.0.1</version>
+      <version>1.1.0</version>
       <scope>provided</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Bumps org.eclipse.sisu.plexus and org.eclipse.sisu.inject to 1.1.0.

Fixes NoSuchMethodError in DefaultPlexusContainer caused by updating org.eclipse.sisu.plexus without corresponding org.eclipse.sisu.inject update.