### PR TITLE
Replace PlexusTestCase.getBasedir() with the plexus-testing shim

### DIFF
--- a/src/test/java/org/apache/maven/plugins/ejb/stub/MavenProjectBasicStub.java
+++ b/src/test/java/org/apache/maven/plugins/ejb/stub/MavenProjectBasicStub.java
@@ -28,7 +28,7 @@ import org.apache.maven.artifact.repository.ArtifactRepository;
 import org.apache.maven.model.Model;
 import org.apache.maven.model.Profile;
 import org.apache.maven.project.MavenProject;
-import org.codehaus.plexus.PlexusTestCase;
+import org.codehaus.plexus.testing.PlexusExtension;
 import org.codehaus.plexus.util.FileUtils;
 
 /**
@@ -60,7 +60,7 @@ public class MavenProjectBasicStub extends MavenProject {
         artifact = new DefaultArtifact(getGroupId(), getArtifactId(), getVersion(), "compile", "jar", "", null);
 
         // set isolated root directory
-        testRootDir = PlexusTestCase.getBasedir() + "/target/test-classes/unit/test-dir/" + identifier;
+        testRootDir = PlexusExtension.getBasedir() + "/target/test-classes/unit/test-dir/" + identifier;
 
         if (!new File(testRootDir).exists()) {
             FileUtils.mkdir(testRootDir);


### PR DESCRIPTION
`MavenProjectBasicStub` was calling the static `PlexusTestCase.getBasedir()` helper — the last direct reference to the JUnit 3-era class in this repo. It now calls `PlexusExtension.getBasedir()` from `plexus-testing`.

No POM change was needed: `junit-jupiter-api` and `junit-vintage-engine` are already declared here, which is why `EjbHelperTest` and `IncludesExcludesTest` were able to run as Jupiter already.

The call is left qualified rather than static-imported, to stay consistent with the same change in maven-rar-plugin, where the stub's own `getBasedir()` override makes an unqualified call recurse infinitely. No such override exists here, but the two stubs are close enough that they should read the same way.

**Not addressed here:** `EjbMojoTest` still extends `AbstractMojoTestCase`, which extends `PlexusTestCase` inside maven-plugin-testing-harness. That inheritance lives in the harness artifact, not in this repo.

### Verification
`mvn test` before and after: `Tests run: 36, Failures: 0, Errors: 0, Skipped: 0`, with the same per-class breakdown (EjbMojoTest 19, EjbHelperTest 10, IncludesExcludesTest 7). `spotless:check` clean.

Draft until CI confirms.

Generated-by: Claude Opus 5 (1M context)