### PR TITLE
Fail when the EJB source directory cannot be created #195

### DIFF
--- a/src/main/java/org/apache/maven/plugins/ejb/EjbMojo.java
+++ b/src/main/java/org/apache/maven/plugins/ejb/EjbMojo.java
@@ -286,9 +286,11 @@ public class EjbMojo extends AbstractMojo {
     public void execute() throws MojoExecutionException {
 
         if (!sourceDirectory.exists()) {
-            getLog().warn("The created EJB jar will be empty cause the " + sourceDirectory.getPath()
-                    + " did not exist.");
-            sourceDirectory.mkdirs();
+            getLog().warn("The created EJB jar will be empty because the source directory " + sourceDirectory.getPath()
+                    + " does not exist.");
+            if (!sourceDirectory.mkdirs() && !sourceDirectory.isDirectory()) {
+                throw new MojoExecutionException("Could not create source directory " + sourceDirectory.getPath());
+            }
         }
 
         File jarFile = generateEjb();

--- a/src/test/java/org/apache/maven/plugins/ejb/EjbMojoTest.java
+++ b/src/test/java/org/apache/maven/plugins/ejb/EjbMojoTest.java
@@ -516,6 +516,23 @@ public class EjbMojoTest extends AbstractMojoTestCase {
         EjbMojo.validateEjbVersion("4.0");
     }
 
+    public void testExecuteFailsWhenSourceDirectoryCannotBeCreated() throws Exception {
+        final MavenProjectResourcesStub project = createTestProject("mkdir-fail");
+        final EjbMojo mojo = lookupMojoWithDefaultSettings(project);
+
+        File blocker = File.createTempFile("ejb-mkdir-blocker", ".tmp");
+        blocker.deleteOnExit();
+        File source = new File(blocker, "classes");
+        setVariableValueToObject(mojo, "sourceDirectory", source);
+
+        try {
+            mojo.execute();
+            fail("MojoExecutionException is expected when the source directory cannot be created");
+        } catch (MojoExecutionException e) {
+            assertTrue(e.getMessage().contains("Could not create source directory"));
+        }
+    }
+
     protected EjbMojo lookupMojo() throws Exception {
         File pomFile = new File(getBasedir(), DEFAULT_POM_PATH);
         EjbMojo mojo = (EjbMojo) lookupMojo("ejb", pomFile);


### PR DESCRIPTION
When the EJB source directory is missing, execute() warned and called mkdirs() without checking the result. I throw MojoExecutionException if the directory still does not exist, and I reworded the warning as in #195.

Unit test covers the case where mkdirs() cannot create the path.

- [x] I hereby declare this contribution to be licenced under the Apache License Version 2.0, January 2004
